### PR TITLE
Update varnish repo to packagecloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ from the varnish-cache repositories.
 | Name | Type | Default Value |
 -------|------|---------------|
 | `package_name` | string | `'varnish'` |
+| `package_version` | string | `nil` (latest minor release of `vendor_version`) |
 | `vendor_repo` | `true` or `false` | `false` |
 | `vendor_version` | string | `'4.0'` |
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,12 @@ varnish_install 'default' do
 end
 ```
 
-Install version 4 from the vendor :
+Install version `4.0.3` (e.g. `4.0.3-5~trusty`) from the vendor :
 
 ```
 varnish_install 'default' do
   package_name 'varnish'
+  package_version '4.0.3-*'
   vendor_repo true
   vendor_version '4.0'
 end

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -33,13 +33,15 @@ class Chef
       end
 
       def add_vendor_repo
+        # packagecloud repos omit dot from major version
+        major_version_no_dot = new_resource.vendor_version.to_s.tr('.', '')
         case node['platform_family']
         when 'debian'
           repo = apt_repository 'varnish-cache' do
-            uri "http://repo.varnish-cache.org/#{node['platform']}"
+            uri "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/#{node['platform']}"
             distribution node['lsb']['codename']
-            components ["varnish-#{new_resource.vendor_version}"]
-            key "http://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt"
+            components ['main']
+            key "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/gpgkey"
             deb_src true
           end
           repo.run_action(:add)
@@ -47,9 +49,9 @@ class Chef
         when 'rhel', 'fedora'
           repo = yum_repository 'varnish' do
             description "Varnish #{new_resource.vendor_version} repo (#{node['platform_version']} - $basearch)"
-            url "http://repo.varnish-cache.org/redhat/varnish-#{new_resource.vendor_version}/el#{node['platform_version'].to_i}/"
+            url "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/el/#{node['platform_version'].to_i}/$basearch"
             gpgcheck false
-            gpgkey 'http://repo.varnish-cache.org/debian/GPG-key.txt'
+            gpgkey "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/gpgkey"
           end
           repo.run_action(:create)
           new_resource.updated_by_last_action(true) if repo.updated_by_last_action?

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -8,6 +8,7 @@ class Chef
 
       attribute :name, kind_of: String, name_attribute: true
       attribute :package_name, kind_of: String, default: 'varnish'
+      attribute :package_version, kind_of: String
       attribute :vendor_repo, kind_of: [TrueClass, FalseClass], default: false
       attribute :vendor_version, kind_of: String, default: '4.0'
     end
@@ -74,6 +75,7 @@ class Chef
 
         pack = package new_resource.package_name do
           action :nothing
+          version new_resource.package_version unless new_resource.package_version.nil?
           notifies 'enable', "service[#{new_resource.package_name}]", 'delayed'
           notifies 'restart', "service[#{new_resource.package_name}]", 'delayed'
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Rackspace'
 maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs and configures varnish'
-version '2.5.0'
+version '2.5.1'
 
 recipe 'varnish', 'Installs and configures varnish'
 recipe 'varnish::repo', 'Adds the official varnish project repository'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -17,23 +17,25 @@
 # limitations under the License.
 #
 
+# packagecloud repos omit dot from major version
+major_version_no_dot = node['varnish']['version'].to_s.tr('.', '')
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
   apt_repository 'varnish-cache' do
-    uri "http://repo.varnish-cache.org/#{node['platform']}"
+    uri "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/#{node['platform']}"
     distribution node['lsb']['codename']
-    components ["varnish-#{node['varnish']['version']}"]
-    key "http://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt"
+    components ['main']
+    key "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/gpgkey"
     deb_src true
     notifies 'nothing', 'execute[apt-get update]', 'immediately'
   end
 when 'rhel', 'fedora'
   yum_repository 'varnish' do
     description "Varnish #{node['varnish']['version']} repo (#{node['platform_version']} - $basearch)"
-    url "http://repo.varnish-cache.org/redhat/varnish-#{node['varnish']['version']}/el#{node['platform_version'].to_i}/"
+    url "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/el/#{node['platform_version'].to_i}/$basearch"
     gpgcheck false
-    gpgkey 'http://repo.varnish-cache.org/debian/GPG-key.txt'
+    gpgkey "https://packagecloud.io/varnishcache/varnish#{major_version_no_dot}/gpgkey"
     action :create
   end
 end

--- a/test/fixtures/cookbooks/install_varnish/recipes/vendor_install.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/vendor_install.rb
@@ -3,7 +3,7 @@ package 'curl'
 
 varnish_install 'default' do
   package_name 'varnish'
-  package_version '4.0.3'
+  package_version '4.0.3-*'
   vendor_repo true
   vendor_version '4.0'
 end

--- a/test/fixtures/cookbooks/install_varnish/recipes/vendor_install.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/vendor_install.rb
@@ -3,6 +3,7 @@ package 'curl'
 
 varnish_install 'default' do
   package_name 'varnish'
+  package_version '4.0.3'
   vendor_repo true
   vendor_version '4.0'
 end


### PR DESCRIPTION
Varnish repo moved from http://repo.varnish-cache.org/ to
https://packagecloud.io/varnishcache